### PR TITLE
Bump to version 3.4.1

### DIFF
--- a/sidekiq-limit_fetch.gemspec
+++ b/sidekiq-limit_fetch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name          = 'rcgt-sidekiq-limit_fetch'
-  gem.version       = '3.4.0'
+  gem.version       = '3.4.1'
   gem.license       = 'MIT'
   gem.authors       = 'RCGT Consulting Inc.'
   gem.email         = 'kumanan.yogaratnam@rcgtconsulting.com'


### PR DESCRIPTION
Bumps the gem version and creates a tag for `v3.4.1` so we have a stable version to work off of